### PR TITLE
fix: change border color from surface0 to overlay0

### DIFF
--- a/templates/bash-zsh.tera
+++ b/templates/bash-zsh.tera
@@ -11,4 +11,4 @@ export FZF_DEFAULT_OPTS=" \
 --color=fg:{{text.hex}},header:{{red.hex}},info:{{mauve.hex}},pointer:{{rosewater.hex}} \
 --color=marker:{{lavender.hex}},fg+:{{text.hex}},prompt:{{mauve.hex}},hl+:{{red.hex}} \
 --color=selected-bg:{{surface1.hex}} \
---color=border:{{surface0.hex}},label:{{text.hex}}"
+--color=border:{{overlay0.hex}},label:{{text.hex}}"

--- a/templates/fish.tera
+++ b/templates/fish.tera
@@ -11,4 +11,4 @@ set -Ux FZF_DEFAULT_OPTS "\
 --color=fg:{{text.hex}},header:{{red.hex}},info:{{mauve.hex}},pointer:{{rosewater.hex}} \
 --color=marker:{{lavender.hex}},fg+:{{text.hex}},prompt:{{mauve.hex}},hl+:{{red.hex}} \
 --color=selected-bg:{{surface1.hex}} \
---color=border:{{surface0.hex}},label:{{text.hex}}"
+--color=border:{{overlay0.hex}},label:{{text.hex}}"

--- a/templates/powershell.tera
+++ b/templates/powershell.tera
@@ -11,5 +11,5 @@ $ENV:FZF_DEFAULT_OPTS=@"
 --color=fg:{{text.hex}},header:{{red.hex}},info:{{mauve.hex}},pointer:{{rosewater.hex}}
 --color=marker:{{lavender.hex}},fg+:{{text.hex}},prompt:{{mauve.hex}},hl+:{{red.hex}}
 --color=selected-bg:{{surface1.hex}}
---color=border:{{surface0.hex}},label:{{text.hex}}
+--color=border:{{overlay0.hex}},label:{{text.hex}}
 "@

--- a/themes/catppuccin-fzf-frappe.fish
+++ b/themes/catppuccin-fzf-frappe.fish
@@ -3,4 +3,4 @@ set -Ux FZF_DEFAULT_OPTS "\
 --color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF \
 --color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284 \
 --color=selected-bg:#51576D \
---color=border:#414559,label:#C6D0F5"
+--color=border:#737994,label:#C6D0F5"

--- a/themes/catppuccin-fzf-frappe.ps1
+++ b/themes/catppuccin-fzf-frappe.ps1
@@ -3,5 +3,5 @@ $ENV:FZF_DEFAULT_OPTS=@"
 --color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF
 --color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284
 --color=selected-bg:#51576D
---color=border:#414559,label:#C6D0F5
+--color=border:#737994,label:#C6D0F5
 "@

--- a/themes/catppuccin-fzf-frappe.sh
+++ b/themes/catppuccin-fzf-frappe.sh
@@ -3,4 +3,4 @@ export FZF_DEFAULT_OPTS=" \
 --color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF \
 --color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284 \
 --color=selected-bg:#51576D \
---color=border:#414559,label:#C6D0F5"
+--color=border:#737994,label:#C6D0F5"

--- a/themes/catppuccin-fzf-latte.fish
+++ b/themes/catppuccin-fzf-latte.fish
@@ -3,4 +3,4 @@ set -Ux FZF_DEFAULT_OPTS "\
 --color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78 \
 --color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39 \
 --color=selected-bg:#BCC0CC \
---color=border:#CCD0DA,label:#4C4F69"
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/catppuccin-fzf-latte.ps1
+++ b/themes/catppuccin-fzf-latte.ps1
@@ -3,5 +3,5 @@ $ENV:FZF_DEFAULT_OPTS=@"
 --color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78
 --color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39
 --color=selected-bg:#BCC0CC
---color=border:#CCD0DA,label:#4C4F69
+--color=border:#9CA0B0,label:#4C4F69
 "@

--- a/themes/catppuccin-fzf-latte.sh
+++ b/themes/catppuccin-fzf-latte.sh
@@ -3,4 +3,4 @@ export FZF_DEFAULT_OPTS=" \
 --color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78 \
 --color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39 \
 --color=selected-bg:#BCC0CC \
---color=border:#CCD0DA,label:#4C4F69"
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/catppuccin-fzf-macchiato.fish
+++ b/themes/catppuccin-fzf-macchiato.fish
@@ -3,4 +3,4 @@ set -Ux FZF_DEFAULT_OPTS "\
 --color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6 \
 --color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796 \
 --color=selected-bg:#494D64 \
---color=border:#363A4F,label:#CAD3F5"
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/catppuccin-fzf-macchiato.ps1
+++ b/themes/catppuccin-fzf-macchiato.ps1
@@ -3,5 +3,5 @@ $ENV:FZF_DEFAULT_OPTS=@"
 --color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6
 --color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796
 --color=selected-bg:#494D64
---color=border:#363A4F,label:#CAD3F5
+--color=border:#6E738D,label:#CAD3F5
 "@

--- a/themes/catppuccin-fzf-macchiato.sh
+++ b/themes/catppuccin-fzf-macchiato.sh
@@ -3,4 +3,4 @@ export FZF_DEFAULT_OPTS=" \
 --color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6 \
 --color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796 \
 --color=selected-bg:#494D64 \
---color=border:#363A4F,label:#CAD3F5"
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/catppuccin-fzf-mocha.fish
+++ b/themes/catppuccin-fzf-mocha.fish
@@ -3,4 +3,4 @@ set -Ux FZF_DEFAULT_OPTS "\
 --color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC \
 --color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8 \
 --color=selected-bg:#45475A \
---color=border:#313244,label:#CDD6F4"
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/catppuccin-fzf-mocha.ps1
+++ b/themes/catppuccin-fzf-mocha.ps1
@@ -3,5 +3,5 @@ $ENV:FZF_DEFAULT_OPTS=@"
 --color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC
 --color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8
 --color=selected-bg:#45475A
---color=border:#313244,label:#CDD6F4
+--color=border:#6C7086,label:#CDD6F4
 "@

--- a/themes/catppuccin-fzf-mocha.sh
+++ b/themes/catppuccin-fzf-mocha.sh
@@ -3,4 +3,4 @@ export FZF_DEFAULT_OPTS=" \
 --color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC \
 --color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8 \
 --color=selected-bg:#45475A \
---color=border:#313244,label:#CDD6F4"
+--color=border:#6C7086,label:#CDD6F4"


### PR DESCRIPTION
The current border color (surface0) is only one shade away from the background (base), which makes the border almost invisible. Instead, overlay0 makes the border stand out better, without making the contrast too strong.

Example frappe before:
<img width="996" height="596" alt="catppuccin-fzf-frappe-before" src="https://github.com/user-attachments/assets/0240824c-3f11-43d3-b338-3dec8154c111" />

After frappe after:
<img width="996" height="596" alt="catppuccin-fzf-frappe-after" src="https://github.com/user-attachments/assets/2a6e9575-6921-4c5e-9190-1b07453843a3" />
