### PR TITLE
feat: add accent support

### DIFF
--- a/fzf.tera
+++ b/fzf.tera
@@ -3,8 +3,9 @@ whiskers:
   version: ^2.5.1
   matrix:
     - flavor
+    - accent
     - variant: ["sh", "fish", "nu", "ps1"]
-  filename: "themes/catppuccin-fzf-{{ flavor.identifier }}.{{ variant }}"
+  filename: "themes/{{ flavor.identifier }}/{{ accent }}/catppuccin-fzf.{{ variant }}"
   hex_format: "#{{R}}{{G}}{{B}}{{Z}}"
 ---
 {% macro line_end() %}
@@ -33,8 +34,8 @@ $ENV:FZF_DEFAULT_OPTS=@"
 {%- endmacro theme_end -%}
 
 {{self::theme_start()}}
---color=bg+:{{surface0.hex}},bg:{{base.hex}},spinner:{{rosewater.hex}},hl:{{red.hex}}{{self::line_end()}}
---color=fg:{{text.hex}},header:{{red.hex}},info:{{mauve.hex}},pointer:{{rosewater.hex}}{{self::line_end()}}
---color=marker:{{lavender.hex}},fg+:{{text.hex}},prompt:{{mauve.hex}},hl+:{{red.hex}}{{self::line_end()}}
+--color=bg+:{{surface0.hex}},bg:{{base.hex}},spinner:{{rosewater.hex}},hl:{{flavor.colors[accent].hex}}{{self::line_end()}}
+--color=fg:{{text.hex}},header:{{flavor.colors[accent].hex}},info:{{flavor.colors[accent].hex}},pointer:{{flavor.colors[accent].hex}}{{self::line_end()}}
+--color=marker:{{flavor.colors[accent].hex}},fg+:{{text.hex}},prompt:{{flavor.colors[accent].hex}},hl+:{{flavor.colors[accent].hex}}{{self::line_end()}}
 --color=selected-bg:{{surface1.hex}}{{self::line_end()}}
 --color=border:{{overlay0.hex}},label:{{text.hex}}{{self::theme_end()}}

--- a/themes/catppuccin-fzf-frappe.fish
+++ b/themes/catppuccin-fzf-frappe.fish
@@ -1,6 +1,0 @@
-set -Ux FZF_DEFAULT_OPTS "\
---color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284 \
---color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF \
---color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284 \
---color=selected-bg:#51576D \
---color=border:#737994,label:#C6D0F5"

--- a/themes/catppuccin-fzf-frappe.nu
+++ b/themes/catppuccin-fzf-frappe.nu
@@ -1,6 +1,0 @@
-$env.FZF_DEFAULT_OPTS = "
---color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284
---color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF
---color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284
---color=selected-bg:#51576D
---color=border:#737994,label:#C6D0F5"

--- a/themes/catppuccin-fzf-frappe.ps1
+++ b/themes/catppuccin-fzf-frappe.ps1
@@ -1,7 +1,0 @@
-$ENV:FZF_DEFAULT_OPTS=@"
---color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284
---color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF
---color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284
---color=selected-bg:#51576D
---color=border:#737994,label:#C6D0F5
-"@

--- a/themes/catppuccin-fzf-frappe.sh
+++ b/themes/catppuccin-fzf-frappe.sh
@@ -1,6 +1,0 @@
-export FZF_DEFAULT_OPTS=" \
---color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284 \
---color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF \
---color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284 \
---color=selected-bg:#51576D \
---color=border:#737994,label:#C6D0F5"

--- a/themes/catppuccin-fzf-latte.fish
+++ b/themes/catppuccin-fzf-latte.fish
@@ -1,6 +1,0 @@
-set -Ux FZF_DEFAULT_OPTS "\
---color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39 \
---color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78 \
---color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39 \
---color=selected-bg:#BCC0CC \
---color=border:#9CA0B0,label:#4C4F69"

--- a/themes/catppuccin-fzf-latte.nu
+++ b/themes/catppuccin-fzf-latte.nu
@@ -1,6 +1,0 @@
-$env.FZF_DEFAULT_OPTS = "
---color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39
---color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78
---color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39
---color=selected-bg:#BCC0CC
---color=border:#9CA0B0,label:#4C4F69"

--- a/themes/catppuccin-fzf-latte.ps1
+++ b/themes/catppuccin-fzf-latte.ps1
@@ -1,7 +1,0 @@
-$ENV:FZF_DEFAULT_OPTS=@"
---color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39
---color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78
---color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39
---color=selected-bg:#BCC0CC
---color=border:#9CA0B0,label:#4C4F69
-"@

--- a/themes/catppuccin-fzf-latte.sh
+++ b/themes/catppuccin-fzf-latte.sh
@@ -1,6 +1,0 @@
-export FZF_DEFAULT_OPTS=" \
---color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39 \
---color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78 \
---color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39 \
---color=selected-bg:#BCC0CC \
---color=border:#9CA0B0,label:#4C4F69"

--- a/themes/catppuccin-fzf-macchiato.fish
+++ b/themes/catppuccin-fzf-macchiato.fish
@@ -1,6 +1,0 @@
-set -Ux FZF_DEFAULT_OPTS "\
---color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796 \
---color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6 \
---color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796 \
---color=selected-bg:#494D64 \
---color=border:#6E738D,label:#CAD3F5"

--- a/themes/catppuccin-fzf-macchiato.nu
+++ b/themes/catppuccin-fzf-macchiato.nu
@@ -1,6 +1,0 @@
-$env.FZF_DEFAULT_OPTS = "
---color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796
---color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6
---color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796
---color=selected-bg:#494D64
---color=border:#6E738D,label:#CAD3F5"

--- a/themes/catppuccin-fzf-macchiato.ps1
+++ b/themes/catppuccin-fzf-macchiato.ps1
@@ -1,7 +1,0 @@
-$ENV:FZF_DEFAULT_OPTS=@"
---color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796
---color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6
---color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796
---color=selected-bg:#494D64
---color=border:#6E738D,label:#CAD3F5
-"@

--- a/themes/catppuccin-fzf-macchiato.sh
+++ b/themes/catppuccin-fzf-macchiato.sh
@@ -1,6 +1,0 @@
-export FZF_DEFAULT_OPTS=" \
---color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796 \
---color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6 \
---color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796 \
---color=selected-bg:#494D64 \
---color=border:#6E738D,label:#CAD3F5"

--- a/themes/catppuccin-fzf-mocha.fish
+++ b/themes/catppuccin-fzf-mocha.fish
@@ -1,6 +1,0 @@
-set -Ux FZF_DEFAULT_OPTS "\
---color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8 \
---color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC \
---color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8 \
---color=selected-bg:#45475A \
---color=border:#6C7086,label:#CDD6F4"

--- a/themes/catppuccin-fzf-mocha.nu
+++ b/themes/catppuccin-fzf-mocha.nu
@@ -1,6 +1,0 @@
-$env.FZF_DEFAULT_OPTS = "
---color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
---color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC
---color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8
---color=selected-bg:#45475A
---color=border:#6C7086,label:#CDD6F4"

--- a/themes/catppuccin-fzf-mocha.ps1
+++ b/themes/catppuccin-fzf-mocha.ps1
@@ -1,7 +1,0 @@
-$ENV:FZF_DEFAULT_OPTS=@"
---color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
---color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC
---color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8
---color=selected-bg:#45475A
---color=border:#6C7086,label:#CDD6F4
-"@

--- a/themes/catppuccin-fzf-mocha.sh
+++ b/themes/catppuccin-fzf-mocha.sh
@@ -1,6 +1,0 @@
-export FZF_DEFAULT_OPTS=" \
---color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8 \
---color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC \
---color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8 \
---color=selected-bg:#45475A \
---color=border:#6C7086,label:#CDD6F4"

--- a/themes/frappe/blue/catppuccin-fzf.fish
+++ b/themes/frappe/blue/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#8CAAEE \
+--color=fg:#C6D0F5,header:#8CAAEE,info:#8CAAEE,pointer:#8CAAEE \
+--color=marker:#8CAAEE,fg+:#C6D0F5,prompt:#8CAAEE,hl+:#8CAAEE \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/blue/catppuccin-fzf.nu
+++ b/themes/frappe/blue/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#8CAAEE
+--color=fg:#C6D0F5,header:#8CAAEE,info:#8CAAEE,pointer:#8CAAEE
+--color=marker:#8CAAEE,fg+:#C6D0F5,prompt:#8CAAEE,hl+:#8CAAEE
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/blue/catppuccin-fzf.ps1
+++ b/themes/frappe/blue/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#8CAAEE
+--color=fg:#C6D0F5,header:#8CAAEE,info:#8CAAEE,pointer:#8CAAEE
+--color=marker:#8CAAEE,fg+:#C6D0F5,prompt:#8CAAEE,hl+:#8CAAEE
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/blue/catppuccin-fzf.sh
+++ b/themes/frappe/blue/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#8CAAEE \
+--color=fg:#C6D0F5,header:#8CAAEE,info:#8CAAEE,pointer:#8CAAEE \
+--color=marker:#8CAAEE,fg+:#C6D0F5,prompt:#8CAAEE,hl+:#8CAAEE \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/flamingo/catppuccin-fzf.fish
+++ b/themes/frappe/flamingo/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EEBEBE \
+--color=fg:#C6D0F5,header:#EEBEBE,info:#EEBEBE,pointer:#EEBEBE \
+--color=marker:#EEBEBE,fg+:#C6D0F5,prompt:#EEBEBE,hl+:#EEBEBE \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/flamingo/catppuccin-fzf.nu
+++ b/themes/frappe/flamingo/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EEBEBE
+--color=fg:#C6D0F5,header:#EEBEBE,info:#EEBEBE,pointer:#EEBEBE
+--color=marker:#EEBEBE,fg+:#C6D0F5,prompt:#EEBEBE,hl+:#EEBEBE
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/flamingo/catppuccin-fzf.ps1
+++ b/themes/frappe/flamingo/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EEBEBE
+--color=fg:#C6D0F5,header:#EEBEBE,info:#EEBEBE,pointer:#EEBEBE
+--color=marker:#EEBEBE,fg+:#C6D0F5,prompt:#EEBEBE,hl+:#EEBEBE
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/flamingo/catppuccin-fzf.sh
+++ b/themes/frappe/flamingo/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EEBEBE \
+--color=fg:#C6D0F5,header:#EEBEBE,info:#EEBEBE,pointer:#EEBEBE \
+--color=marker:#EEBEBE,fg+:#C6D0F5,prompt:#EEBEBE,hl+:#EEBEBE \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/green/catppuccin-fzf.fish
+++ b/themes/frappe/green/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#A6D189 \
+--color=fg:#C6D0F5,header:#A6D189,info:#A6D189,pointer:#A6D189 \
+--color=marker:#A6D189,fg+:#C6D0F5,prompt:#A6D189,hl+:#A6D189 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/green/catppuccin-fzf.nu
+++ b/themes/frappe/green/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#A6D189
+--color=fg:#C6D0F5,header:#A6D189,info:#A6D189,pointer:#A6D189
+--color=marker:#A6D189,fg+:#C6D0F5,prompt:#A6D189,hl+:#A6D189
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/green/catppuccin-fzf.ps1
+++ b/themes/frappe/green/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#A6D189
+--color=fg:#C6D0F5,header:#A6D189,info:#A6D189,pointer:#A6D189
+--color=marker:#A6D189,fg+:#C6D0F5,prompt:#A6D189,hl+:#A6D189
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/green/catppuccin-fzf.sh
+++ b/themes/frappe/green/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#A6D189 \
+--color=fg:#C6D0F5,header:#A6D189,info:#A6D189,pointer:#A6D189 \
+--color=marker:#A6D189,fg+:#C6D0F5,prompt:#A6D189,hl+:#A6D189 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/lavender/catppuccin-fzf.fish
+++ b/themes/frappe/lavender/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#BABBF1 \
+--color=fg:#C6D0F5,header:#BABBF1,info:#BABBF1,pointer:#BABBF1 \
+--color=marker:#BABBF1,fg+:#C6D0F5,prompt:#BABBF1,hl+:#BABBF1 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/lavender/catppuccin-fzf.nu
+++ b/themes/frappe/lavender/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#BABBF1
+--color=fg:#C6D0F5,header:#BABBF1,info:#BABBF1,pointer:#BABBF1
+--color=marker:#BABBF1,fg+:#C6D0F5,prompt:#BABBF1,hl+:#BABBF1
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/lavender/catppuccin-fzf.ps1
+++ b/themes/frappe/lavender/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#BABBF1
+--color=fg:#C6D0F5,header:#BABBF1,info:#BABBF1,pointer:#BABBF1
+--color=marker:#BABBF1,fg+:#C6D0F5,prompt:#BABBF1,hl+:#BABBF1
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/lavender/catppuccin-fzf.sh
+++ b/themes/frappe/lavender/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#BABBF1 \
+--color=fg:#C6D0F5,header:#BABBF1,info:#BABBF1,pointer:#BABBF1 \
+--color=marker:#BABBF1,fg+:#C6D0F5,prompt:#BABBF1,hl+:#BABBF1 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/maroon/catppuccin-fzf.fish
+++ b/themes/frappe/maroon/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EA999C \
+--color=fg:#C6D0F5,header:#EA999C,info:#EA999C,pointer:#EA999C \
+--color=marker:#EA999C,fg+:#C6D0F5,prompt:#EA999C,hl+:#EA999C \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/maroon/catppuccin-fzf.nu
+++ b/themes/frappe/maroon/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EA999C
+--color=fg:#C6D0F5,header:#EA999C,info:#EA999C,pointer:#EA999C
+--color=marker:#EA999C,fg+:#C6D0F5,prompt:#EA999C,hl+:#EA999C
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/maroon/catppuccin-fzf.ps1
+++ b/themes/frappe/maroon/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EA999C
+--color=fg:#C6D0F5,header:#EA999C,info:#EA999C,pointer:#EA999C
+--color=marker:#EA999C,fg+:#C6D0F5,prompt:#EA999C,hl+:#EA999C
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/maroon/catppuccin-fzf.sh
+++ b/themes/frappe/maroon/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EA999C \
+--color=fg:#C6D0F5,header:#EA999C,info:#EA999C,pointer:#EA999C \
+--color=marker:#EA999C,fg+:#C6D0F5,prompt:#EA999C,hl+:#EA999C \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/mauve/catppuccin-fzf.fish
+++ b/themes/frappe/mauve/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#CA9EE6 \
+--color=fg:#C6D0F5,header:#CA9EE6,info:#CA9EE6,pointer:#CA9EE6 \
+--color=marker:#CA9EE6,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#CA9EE6 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/mauve/catppuccin-fzf.nu
+++ b/themes/frappe/mauve/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#CA9EE6
+--color=fg:#C6D0F5,header:#CA9EE6,info:#CA9EE6,pointer:#CA9EE6
+--color=marker:#CA9EE6,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#CA9EE6
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/mauve/catppuccin-fzf.ps1
+++ b/themes/frappe/mauve/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#CA9EE6
+--color=fg:#C6D0F5,header:#CA9EE6,info:#CA9EE6,pointer:#CA9EE6
+--color=marker:#CA9EE6,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#CA9EE6
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/mauve/catppuccin-fzf.sh
+++ b/themes/frappe/mauve/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#CA9EE6 \
+--color=fg:#C6D0F5,header:#CA9EE6,info:#CA9EE6,pointer:#CA9EE6 \
+--color=marker:#CA9EE6,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#CA9EE6 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/peach/catppuccin-fzf.fish
+++ b/themes/frappe/peach/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EF9F76 \
+--color=fg:#C6D0F5,header:#EF9F76,info:#EF9F76,pointer:#EF9F76 \
+--color=marker:#EF9F76,fg+:#C6D0F5,prompt:#EF9F76,hl+:#EF9F76 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/peach/catppuccin-fzf.nu
+++ b/themes/frappe/peach/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EF9F76
+--color=fg:#C6D0F5,header:#EF9F76,info:#EF9F76,pointer:#EF9F76
+--color=marker:#EF9F76,fg+:#C6D0F5,prompt:#EF9F76,hl+:#EF9F76
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/peach/catppuccin-fzf.ps1
+++ b/themes/frappe/peach/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EF9F76
+--color=fg:#C6D0F5,header:#EF9F76,info:#EF9F76,pointer:#EF9F76
+--color=marker:#EF9F76,fg+:#C6D0F5,prompt:#EF9F76,hl+:#EF9F76
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/peach/catppuccin-fzf.sh
+++ b/themes/frappe/peach/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#EF9F76 \
+--color=fg:#C6D0F5,header:#EF9F76,info:#EF9F76,pointer:#EF9F76 \
+--color=marker:#EF9F76,fg+:#C6D0F5,prompt:#EF9F76,hl+:#EF9F76 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/pink/catppuccin-fzf.fish
+++ b/themes/frappe/pink/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F4B8E4 \
+--color=fg:#C6D0F5,header:#F4B8E4,info:#F4B8E4,pointer:#F4B8E4 \
+--color=marker:#F4B8E4,fg+:#C6D0F5,prompt:#F4B8E4,hl+:#F4B8E4 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/pink/catppuccin-fzf.nu
+++ b/themes/frappe/pink/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F4B8E4
+--color=fg:#C6D0F5,header:#F4B8E4,info:#F4B8E4,pointer:#F4B8E4
+--color=marker:#F4B8E4,fg+:#C6D0F5,prompt:#F4B8E4,hl+:#F4B8E4
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/pink/catppuccin-fzf.ps1
+++ b/themes/frappe/pink/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F4B8E4
+--color=fg:#C6D0F5,header:#F4B8E4,info:#F4B8E4,pointer:#F4B8E4
+--color=marker:#F4B8E4,fg+:#C6D0F5,prompt:#F4B8E4,hl+:#F4B8E4
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/pink/catppuccin-fzf.sh
+++ b/themes/frappe/pink/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F4B8E4 \
+--color=fg:#C6D0F5,header:#F4B8E4,info:#F4B8E4,pointer:#F4B8E4 \
+--color=marker:#F4B8E4,fg+:#C6D0F5,prompt:#F4B8E4,hl+:#F4B8E4 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/red/catppuccin-fzf.fish
+++ b/themes/frappe/red/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284 \
+--color=fg:#C6D0F5,header:#E78284,info:#E78284,pointer:#E78284 \
+--color=marker:#E78284,fg+:#C6D0F5,prompt:#E78284,hl+:#E78284 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/red/catppuccin-fzf.nu
+++ b/themes/frappe/red/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284
+--color=fg:#C6D0F5,header:#E78284,info:#E78284,pointer:#E78284
+--color=marker:#E78284,fg+:#C6D0F5,prompt:#E78284,hl+:#E78284
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/red/catppuccin-fzf.ps1
+++ b/themes/frappe/red/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284
+--color=fg:#C6D0F5,header:#E78284,info:#E78284,pointer:#E78284
+--color=marker:#E78284,fg+:#C6D0F5,prompt:#E78284,hl+:#E78284
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/red/catppuccin-fzf.sh
+++ b/themes/frappe/red/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284 \
+--color=fg:#C6D0F5,header:#E78284,info:#E78284,pointer:#E78284 \
+--color=marker:#E78284,fg+:#C6D0F5,prompt:#E78284,hl+:#E78284 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/rosewater/catppuccin-fzf.fish
+++ b/themes/frappe/rosewater/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F2D5CF \
+--color=fg:#C6D0F5,header:#F2D5CF,info:#F2D5CF,pointer:#F2D5CF \
+--color=marker:#F2D5CF,fg+:#C6D0F5,prompt:#F2D5CF,hl+:#F2D5CF \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/rosewater/catppuccin-fzf.nu
+++ b/themes/frappe/rosewater/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F2D5CF
+--color=fg:#C6D0F5,header:#F2D5CF,info:#F2D5CF,pointer:#F2D5CF
+--color=marker:#F2D5CF,fg+:#C6D0F5,prompt:#F2D5CF,hl+:#F2D5CF
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/rosewater/catppuccin-fzf.ps1
+++ b/themes/frappe/rosewater/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F2D5CF
+--color=fg:#C6D0F5,header:#F2D5CF,info:#F2D5CF,pointer:#F2D5CF
+--color=marker:#F2D5CF,fg+:#C6D0F5,prompt:#F2D5CF,hl+:#F2D5CF
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/rosewater/catppuccin-fzf.sh
+++ b/themes/frappe/rosewater/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#F2D5CF \
+--color=fg:#C6D0F5,header:#F2D5CF,info:#F2D5CF,pointer:#F2D5CF \
+--color=marker:#F2D5CF,fg+:#C6D0F5,prompt:#F2D5CF,hl+:#F2D5CF \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/sapphire/catppuccin-fzf.fish
+++ b/themes/frappe/sapphire/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#85C1DC \
+--color=fg:#C6D0F5,header:#85C1DC,info:#85C1DC,pointer:#85C1DC \
+--color=marker:#85C1DC,fg+:#C6D0F5,prompt:#85C1DC,hl+:#85C1DC \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/sapphire/catppuccin-fzf.nu
+++ b/themes/frappe/sapphire/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#85C1DC
+--color=fg:#C6D0F5,header:#85C1DC,info:#85C1DC,pointer:#85C1DC
+--color=marker:#85C1DC,fg+:#C6D0F5,prompt:#85C1DC,hl+:#85C1DC
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/sapphire/catppuccin-fzf.ps1
+++ b/themes/frappe/sapphire/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#85C1DC
+--color=fg:#C6D0F5,header:#85C1DC,info:#85C1DC,pointer:#85C1DC
+--color=marker:#85C1DC,fg+:#C6D0F5,prompt:#85C1DC,hl+:#85C1DC
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/sapphire/catppuccin-fzf.sh
+++ b/themes/frappe/sapphire/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#85C1DC \
+--color=fg:#C6D0F5,header:#85C1DC,info:#85C1DC,pointer:#85C1DC \
+--color=marker:#85C1DC,fg+:#C6D0F5,prompt:#85C1DC,hl+:#85C1DC \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/sky/catppuccin-fzf.fish
+++ b/themes/frappe/sky/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#99D1DB \
+--color=fg:#C6D0F5,header:#99D1DB,info:#99D1DB,pointer:#99D1DB \
+--color=marker:#99D1DB,fg+:#C6D0F5,prompt:#99D1DB,hl+:#99D1DB \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/sky/catppuccin-fzf.nu
+++ b/themes/frappe/sky/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#99D1DB
+--color=fg:#C6D0F5,header:#99D1DB,info:#99D1DB,pointer:#99D1DB
+--color=marker:#99D1DB,fg+:#C6D0F5,prompt:#99D1DB,hl+:#99D1DB
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/sky/catppuccin-fzf.ps1
+++ b/themes/frappe/sky/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#99D1DB
+--color=fg:#C6D0F5,header:#99D1DB,info:#99D1DB,pointer:#99D1DB
+--color=marker:#99D1DB,fg+:#C6D0F5,prompt:#99D1DB,hl+:#99D1DB
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/sky/catppuccin-fzf.sh
+++ b/themes/frappe/sky/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#99D1DB \
+--color=fg:#C6D0F5,header:#99D1DB,info:#99D1DB,pointer:#99D1DB \
+--color=marker:#99D1DB,fg+:#C6D0F5,prompt:#99D1DB,hl+:#99D1DB \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/teal/catppuccin-fzf.fish
+++ b/themes/frappe/teal/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#81C8BE \
+--color=fg:#C6D0F5,header:#81C8BE,info:#81C8BE,pointer:#81C8BE \
+--color=marker:#81C8BE,fg+:#C6D0F5,prompt:#81C8BE,hl+:#81C8BE \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/teal/catppuccin-fzf.nu
+++ b/themes/frappe/teal/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#81C8BE
+--color=fg:#C6D0F5,header:#81C8BE,info:#81C8BE,pointer:#81C8BE
+--color=marker:#81C8BE,fg+:#C6D0F5,prompt:#81C8BE,hl+:#81C8BE
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/teal/catppuccin-fzf.ps1
+++ b/themes/frappe/teal/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#81C8BE
+--color=fg:#C6D0F5,header:#81C8BE,info:#81C8BE,pointer:#81C8BE
+--color=marker:#81C8BE,fg+:#C6D0F5,prompt:#81C8BE,hl+:#81C8BE
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/teal/catppuccin-fzf.sh
+++ b/themes/frappe/teal/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#81C8BE \
+--color=fg:#C6D0F5,header:#81C8BE,info:#81C8BE,pointer:#81C8BE \
+--color=marker:#81C8BE,fg+:#C6D0F5,prompt:#81C8BE,hl+:#81C8BE \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/yellow/catppuccin-fzf.fish
+++ b/themes/frappe/yellow/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E5C890 \
+--color=fg:#C6D0F5,header:#E5C890,info:#E5C890,pointer:#E5C890 \
+--color=marker:#E5C890,fg+:#C6D0F5,prompt:#E5C890,hl+:#E5C890 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/yellow/catppuccin-fzf.nu
+++ b/themes/frappe/yellow/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E5C890
+--color=fg:#C6D0F5,header:#E5C890,info:#E5C890,pointer:#E5C890
+--color=marker:#E5C890,fg+:#C6D0F5,prompt:#E5C890,hl+:#E5C890
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5"

--- a/themes/frappe/yellow/catppuccin-fzf.ps1
+++ b/themes/frappe/yellow/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E5C890
+--color=fg:#C6D0F5,header:#E5C890,info:#E5C890,pointer:#E5C890
+--color=marker:#E5C890,fg+:#C6D0F5,prompt:#E5C890,hl+:#E5C890
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5
+"@

--- a/themes/frappe/yellow/catppuccin-fzf.sh
+++ b/themes/frappe/yellow/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E5C890 \
+--color=fg:#C6D0F5,header:#E5C890,info:#E5C890,pointer:#E5C890 \
+--color=marker:#E5C890,fg+:#C6D0F5,prompt:#E5C890,hl+:#E5C890 \
+--color=selected-bg:#51576D \
+--color=border:#737994,label:#C6D0F5"

--- a/themes/latte/blue/catppuccin-fzf.fish
+++ b/themes/latte/blue/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#1E66F5 \
+--color=fg:#4C4F69,header:#1E66F5,info:#1E66F5,pointer:#1E66F5 \
+--color=marker:#1E66F5,fg+:#4C4F69,prompt:#1E66F5,hl+:#1E66F5 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/blue/catppuccin-fzf.nu
+++ b/themes/latte/blue/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#1E66F5
+--color=fg:#4C4F69,header:#1E66F5,info:#1E66F5,pointer:#1E66F5
+--color=marker:#1E66F5,fg+:#4C4F69,prompt:#1E66F5,hl+:#1E66F5
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/blue/catppuccin-fzf.ps1
+++ b/themes/latte/blue/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#1E66F5
+--color=fg:#4C4F69,header:#1E66F5,info:#1E66F5,pointer:#1E66F5
+--color=marker:#1E66F5,fg+:#4C4F69,prompt:#1E66F5,hl+:#1E66F5
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/blue/catppuccin-fzf.sh
+++ b/themes/latte/blue/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#1E66F5 \
+--color=fg:#4C4F69,header:#1E66F5,info:#1E66F5,pointer:#1E66F5 \
+--color=marker:#1E66F5,fg+:#4C4F69,prompt:#1E66F5,hl+:#1E66F5 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/flamingo/catppuccin-fzf.fish
+++ b/themes/latte/flamingo/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DD7878 \
+--color=fg:#4C4F69,header:#DD7878,info:#DD7878,pointer:#DD7878 \
+--color=marker:#DD7878,fg+:#4C4F69,prompt:#DD7878,hl+:#DD7878 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/flamingo/catppuccin-fzf.nu
+++ b/themes/latte/flamingo/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DD7878
+--color=fg:#4C4F69,header:#DD7878,info:#DD7878,pointer:#DD7878
+--color=marker:#DD7878,fg+:#4C4F69,prompt:#DD7878,hl+:#DD7878
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/flamingo/catppuccin-fzf.ps1
+++ b/themes/latte/flamingo/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DD7878
+--color=fg:#4C4F69,header:#DD7878,info:#DD7878,pointer:#DD7878
+--color=marker:#DD7878,fg+:#4C4F69,prompt:#DD7878,hl+:#DD7878
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/flamingo/catppuccin-fzf.sh
+++ b/themes/latte/flamingo/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DD7878 \
+--color=fg:#4C4F69,header:#DD7878,info:#DD7878,pointer:#DD7878 \
+--color=marker:#DD7878,fg+:#4C4F69,prompt:#DD7878,hl+:#DD7878 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/green/catppuccin-fzf.fish
+++ b/themes/latte/green/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#40A02B \
+--color=fg:#4C4F69,header:#40A02B,info:#40A02B,pointer:#40A02B \
+--color=marker:#40A02B,fg+:#4C4F69,prompt:#40A02B,hl+:#40A02B \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/green/catppuccin-fzf.nu
+++ b/themes/latte/green/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#40A02B
+--color=fg:#4C4F69,header:#40A02B,info:#40A02B,pointer:#40A02B
+--color=marker:#40A02B,fg+:#4C4F69,prompt:#40A02B,hl+:#40A02B
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/green/catppuccin-fzf.ps1
+++ b/themes/latte/green/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#40A02B
+--color=fg:#4C4F69,header:#40A02B,info:#40A02B,pointer:#40A02B
+--color=marker:#40A02B,fg+:#4C4F69,prompt:#40A02B,hl+:#40A02B
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/green/catppuccin-fzf.sh
+++ b/themes/latte/green/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#40A02B \
+--color=fg:#4C4F69,header:#40A02B,info:#40A02B,pointer:#40A02B \
+--color=marker:#40A02B,fg+:#4C4F69,prompt:#40A02B,hl+:#40A02B \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/lavender/catppuccin-fzf.fish
+++ b/themes/latte/lavender/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#7287FD \
+--color=fg:#4C4F69,header:#7287FD,info:#7287FD,pointer:#7287FD \
+--color=marker:#7287FD,fg+:#4C4F69,prompt:#7287FD,hl+:#7287FD \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/lavender/catppuccin-fzf.nu
+++ b/themes/latte/lavender/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#7287FD
+--color=fg:#4C4F69,header:#7287FD,info:#7287FD,pointer:#7287FD
+--color=marker:#7287FD,fg+:#4C4F69,prompt:#7287FD,hl+:#7287FD
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/lavender/catppuccin-fzf.ps1
+++ b/themes/latte/lavender/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#7287FD
+--color=fg:#4C4F69,header:#7287FD,info:#7287FD,pointer:#7287FD
+--color=marker:#7287FD,fg+:#4C4F69,prompt:#7287FD,hl+:#7287FD
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/lavender/catppuccin-fzf.sh
+++ b/themes/latte/lavender/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#7287FD \
+--color=fg:#4C4F69,header:#7287FD,info:#7287FD,pointer:#7287FD \
+--color=marker:#7287FD,fg+:#4C4F69,prompt:#7287FD,hl+:#7287FD \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/maroon/catppuccin-fzf.fish
+++ b/themes/latte/maroon/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#E64553 \
+--color=fg:#4C4F69,header:#E64553,info:#E64553,pointer:#E64553 \
+--color=marker:#E64553,fg+:#4C4F69,prompt:#E64553,hl+:#E64553 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/maroon/catppuccin-fzf.nu
+++ b/themes/latte/maroon/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#E64553
+--color=fg:#4C4F69,header:#E64553,info:#E64553,pointer:#E64553
+--color=marker:#E64553,fg+:#4C4F69,prompt:#E64553,hl+:#E64553
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/maroon/catppuccin-fzf.ps1
+++ b/themes/latte/maroon/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#E64553
+--color=fg:#4C4F69,header:#E64553,info:#E64553,pointer:#E64553
+--color=marker:#E64553,fg+:#4C4F69,prompt:#E64553,hl+:#E64553
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/maroon/catppuccin-fzf.sh
+++ b/themes/latte/maroon/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#E64553 \
+--color=fg:#4C4F69,header:#E64553,info:#E64553,pointer:#E64553 \
+--color=marker:#E64553,fg+:#4C4F69,prompt:#E64553,hl+:#E64553 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/mauve/catppuccin-fzf.fish
+++ b/themes/latte/mauve/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#8839EF \
+--color=fg:#4C4F69,header:#8839EF,info:#8839EF,pointer:#8839EF \
+--color=marker:#8839EF,fg+:#4C4F69,prompt:#8839EF,hl+:#8839EF \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/mauve/catppuccin-fzf.nu
+++ b/themes/latte/mauve/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#8839EF
+--color=fg:#4C4F69,header:#8839EF,info:#8839EF,pointer:#8839EF
+--color=marker:#8839EF,fg+:#4C4F69,prompt:#8839EF,hl+:#8839EF
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/mauve/catppuccin-fzf.ps1
+++ b/themes/latte/mauve/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#8839EF
+--color=fg:#4C4F69,header:#8839EF,info:#8839EF,pointer:#8839EF
+--color=marker:#8839EF,fg+:#4C4F69,prompt:#8839EF,hl+:#8839EF
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/mauve/catppuccin-fzf.sh
+++ b/themes/latte/mauve/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#8839EF \
+--color=fg:#4C4F69,header:#8839EF,info:#8839EF,pointer:#8839EF \
+--color=marker:#8839EF,fg+:#4C4F69,prompt:#8839EF,hl+:#8839EF \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/peach/catppuccin-fzf.fish
+++ b/themes/latte/peach/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#FE640B \
+--color=fg:#4C4F69,header:#FE640B,info:#FE640B,pointer:#FE640B \
+--color=marker:#FE640B,fg+:#4C4F69,prompt:#FE640B,hl+:#FE640B \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/peach/catppuccin-fzf.nu
+++ b/themes/latte/peach/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#FE640B
+--color=fg:#4C4F69,header:#FE640B,info:#FE640B,pointer:#FE640B
+--color=marker:#FE640B,fg+:#4C4F69,prompt:#FE640B,hl+:#FE640B
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/peach/catppuccin-fzf.ps1
+++ b/themes/latte/peach/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#FE640B
+--color=fg:#4C4F69,header:#FE640B,info:#FE640B,pointer:#FE640B
+--color=marker:#FE640B,fg+:#4C4F69,prompt:#FE640B,hl+:#FE640B
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/peach/catppuccin-fzf.sh
+++ b/themes/latte/peach/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#FE640B \
+--color=fg:#4C4F69,header:#FE640B,info:#FE640B,pointer:#FE640B \
+--color=marker:#FE640B,fg+:#4C4F69,prompt:#FE640B,hl+:#FE640B \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/pink/catppuccin-fzf.fish
+++ b/themes/latte/pink/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#EA76CB \
+--color=fg:#4C4F69,header:#EA76CB,info:#EA76CB,pointer:#EA76CB \
+--color=marker:#EA76CB,fg+:#4C4F69,prompt:#EA76CB,hl+:#EA76CB \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/pink/catppuccin-fzf.nu
+++ b/themes/latte/pink/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#EA76CB
+--color=fg:#4C4F69,header:#EA76CB,info:#EA76CB,pointer:#EA76CB
+--color=marker:#EA76CB,fg+:#4C4F69,prompt:#EA76CB,hl+:#EA76CB
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/pink/catppuccin-fzf.ps1
+++ b/themes/latte/pink/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#EA76CB
+--color=fg:#4C4F69,header:#EA76CB,info:#EA76CB,pointer:#EA76CB
+--color=marker:#EA76CB,fg+:#4C4F69,prompt:#EA76CB,hl+:#EA76CB
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/pink/catppuccin-fzf.sh
+++ b/themes/latte/pink/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#EA76CB \
+--color=fg:#4C4F69,header:#EA76CB,info:#EA76CB,pointer:#EA76CB \
+--color=marker:#EA76CB,fg+:#4C4F69,prompt:#EA76CB,hl+:#EA76CB \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/red/catppuccin-fzf.fish
+++ b/themes/latte/red/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39 \
+--color=fg:#4C4F69,header:#D20F39,info:#D20F39,pointer:#D20F39 \
+--color=marker:#D20F39,fg+:#4C4F69,prompt:#D20F39,hl+:#D20F39 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/red/catppuccin-fzf.nu
+++ b/themes/latte/red/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39
+--color=fg:#4C4F69,header:#D20F39,info:#D20F39,pointer:#D20F39
+--color=marker:#D20F39,fg+:#4C4F69,prompt:#D20F39,hl+:#D20F39
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/red/catppuccin-fzf.ps1
+++ b/themes/latte/red/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39
+--color=fg:#4C4F69,header:#D20F39,info:#D20F39,pointer:#D20F39
+--color=marker:#D20F39,fg+:#4C4F69,prompt:#D20F39,hl+:#D20F39
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/red/catppuccin-fzf.sh
+++ b/themes/latte/red/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39 \
+--color=fg:#4C4F69,header:#D20F39,info:#D20F39,pointer:#D20F39 \
+--color=marker:#D20F39,fg+:#4C4F69,prompt:#D20F39,hl+:#D20F39 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/rosewater/catppuccin-fzf.fish
+++ b/themes/latte/rosewater/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DC8A78 \
+--color=fg:#4C4F69,header:#DC8A78,info:#DC8A78,pointer:#DC8A78 \
+--color=marker:#DC8A78,fg+:#4C4F69,prompt:#DC8A78,hl+:#DC8A78 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/rosewater/catppuccin-fzf.nu
+++ b/themes/latte/rosewater/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DC8A78
+--color=fg:#4C4F69,header:#DC8A78,info:#DC8A78,pointer:#DC8A78
+--color=marker:#DC8A78,fg+:#4C4F69,prompt:#DC8A78,hl+:#DC8A78
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/rosewater/catppuccin-fzf.ps1
+++ b/themes/latte/rosewater/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DC8A78
+--color=fg:#4C4F69,header:#DC8A78,info:#DC8A78,pointer:#DC8A78
+--color=marker:#DC8A78,fg+:#4C4F69,prompt:#DC8A78,hl+:#DC8A78
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/rosewater/catppuccin-fzf.sh
+++ b/themes/latte/rosewater/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DC8A78 \
+--color=fg:#4C4F69,header:#DC8A78,info:#DC8A78,pointer:#DC8A78 \
+--color=marker:#DC8A78,fg+:#4C4F69,prompt:#DC8A78,hl+:#DC8A78 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/sapphire/catppuccin-fzf.fish
+++ b/themes/latte/sapphire/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#209FB5 \
+--color=fg:#4C4F69,header:#209FB5,info:#209FB5,pointer:#209FB5 \
+--color=marker:#209FB5,fg+:#4C4F69,prompt:#209FB5,hl+:#209FB5 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/sapphire/catppuccin-fzf.nu
+++ b/themes/latte/sapphire/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#209FB5
+--color=fg:#4C4F69,header:#209FB5,info:#209FB5,pointer:#209FB5
+--color=marker:#209FB5,fg+:#4C4F69,prompt:#209FB5,hl+:#209FB5
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/sapphire/catppuccin-fzf.ps1
+++ b/themes/latte/sapphire/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#209FB5
+--color=fg:#4C4F69,header:#209FB5,info:#209FB5,pointer:#209FB5
+--color=marker:#209FB5,fg+:#4C4F69,prompt:#209FB5,hl+:#209FB5
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/sapphire/catppuccin-fzf.sh
+++ b/themes/latte/sapphire/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#209FB5 \
+--color=fg:#4C4F69,header:#209FB5,info:#209FB5,pointer:#209FB5 \
+--color=marker:#209FB5,fg+:#4C4F69,prompt:#209FB5,hl+:#209FB5 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/sky/catppuccin-fzf.fish
+++ b/themes/latte/sky/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#04A5E5 \
+--color=fg:#4C4F69,header:#04A5E5,info:#04A5E5,pointer:#04A5E5 \
+--color=marker:#04A5E5,fg+:#4C4F69,prompt:#04A5E5,hl+:#04A5E5 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/sky/catppuccin-fzf.nu
+++ b/themes/latte/sky/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#04A5E5
+--color=fg:#4C4F69,header:#04A5E5,info:#04A5E5,pointer:#04A5E5
+--color=marker:#04A5E5,fg+:#4C4F69,prompt:#04A5E5,hl+:#04A5E5
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/sky/catppuccin-fzf.ps1
+++ b/themes/latte/sky/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#04A5E5
+--color=fg:#4C4F69,header:#04A5E5,info:#04A5E5,pointer:#04A5E5
+--color=marker:#04A5E5,fg+:#4C4F69,prompt:#04A5E5,hl+:#04A5E5
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/sky/catppuccin-fzf.sh
+++ b/themes/latte/sky/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#04A5E5 \
+--color=fg:#4C4F69,header:#04A5E5,info:#04A5E5,pointer:#04A5E5 \
+--color=marker:#04A5E5,fg+:#4C4F69,prompt:#04A5E5,hl+:#04A5E5 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/teal/catppuccin-fzf.fish
+++ b/themes/latte/teal/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#179299 \
+--color=fg:#4C4F69,header:#179299,info:#179299,pointer:#179299 \
+--color=marker:#179299,fg+:#4C4F69,prompt:#179299,hl+:#179299 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/teal/catppuccin-fzf.nu
+++ b/themes/latte/teal/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#179299
+--color=fg:#4C4F69,header:#179299,info:#179299,pointer:#179299
+--color=marker:#179299,fg+:#4C4F69,prompt:#179299,hl+:#179299
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/teal/catppuccin-fzf.ps1
+++ b/themes/latte/teal/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#179299
+--color=fg:#4C4F69,header:#179299,info:#179299,pointer:#179299
+--color=marker:#179299,fg+:#4C4F69,prompt:#179299,hl+:#179299
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/teal/catppuccin-fzf.sh
+++ b/themes/latte/teal/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#179299 \
+--color=fg:#4C4F69,header:#179299,info:#179299,pointer:#179299 \
+--color=marker:#179299,fg+:#4C4F69,prompt:#179299,hl+:#179299 \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/yellow/catppuccin-fzf.fish
+++ b/themes/latte/yellow/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DF8E1D \
+--color=fg:#4C4F69,header:#DF8E1D,info:#DF8E1D,pointer:#DF8E1D \
+--color=marker:#DF8E1D,fg+:#4C4F69,prompt:#DF8E1D,hl+:#DF8E1D \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/yellow/catppuccin-fzf.nu
+++ b/themes/latte/yellow/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DF8E1D
+--color=fg:#4C4F69,header:#DF8E1D,info:#DF8E1D,pointer:#DF8E1D
+--color=marker:#DF8E1D,fg+:#4C4F69,prompt:#DF8E1D,hl+:#DF8E1D
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/latte/yellow/catppuccin-fzf.ps1
+++ b/themes/latte/yellow/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DF8E1D
+--color=fg:#4C4F69,header:#DF8E1D,info:#DF8E1D,pointer:#DF8E1D
+--color=marker:#DF8E1D,fg+:#4C4F69,prompt:#DF8E1D,hl+:#DF8E1D
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69
+"@

--- a/themes/latte/yellow/catppuccin-fzf.sh
+++ b/themes/latte/yellow/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#DF8E1D \
+--color=fg:#4C4F69,header:#DF8E1D,info:#DF8E1D,pointer:#DF8E1D \
+--color=marker:#DF8E1D,fg+:#4C4F69,prompt:#DF8E1D,hl+:#DF8E1D \
+--color=selected-bg:#BCC0CC \
+--color=border:#9CA0B0,label:#4C4F69"

--- a/themes/macchiato/blue/catppuccin-fzf.fish
+++ b/themes/macchiato/blue/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8AADF4 \
+--color=fg:#CAD3F5,header:#8AADF4,info:#8AADF4,pointer:#8AADF4 \
+--color=marker:#8AADF4,fg+:#CAD3F5,prompt:#8AADF4,hl+:#8AADF4 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/blue/catppuccin-fzf.nu
+++ b/themes/macchiato/blue/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8AADF4
+--color=fg:#CAD3F5,header:#8AADF4,info:#8AADF4,pointer:#8AADF4
+--color=marker:#8AADF4,fg+:#CAD3F5,prompt:#8AADF4,hl+:#8AADF4
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/blue/catppuccin-fzf.ps1
+++ b/themes/macchiato/blue/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8AADF4
+--color=fg:#CAD3F5,header:#8AADF4,info:#8AADF4,pointer:#8AADF4
+--color=marker:#8AADF4,fg+:#CAD3F5,prompt:#8AADF4,hl+:#8AADF4
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/blue/catppuccin-fzf.sh
+++ b/themes/macchiato/blue/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8AADF4 \
+--color=fg:#CAD3F5,header:#8AADF4,info:#8AADF4,pointer:#8AADF4 \
+--color=marker:#8AADF4,fg+:#CAD3F5,prompt:#8AADF4,hl+:#8AADF4 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/flamingo/catppuccin-fzf.fish
+++ b/themes/macchiato/flamingo/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F0C6C6 \
+--color=fg:#CAD3F5,header:#F0C6C6,info:#F0C6C6,pointer:#F0C6C6 \
+--color=marker:#F0C6C6,fg+:#CAD3F5,prompt:#F0C6C6,hl+:#F0C6C6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/flamingo/catppuccin-fzf.nu
+++ b/themes/macchiato/flamingo/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F0C6C6
+--color=fg:#CAD3F5,header:#F0C6C6,info:#F0C6C6,pointer:#F0C6C6
+--color=marker:#F0C6C6,fg+:#CAD3F5,prompt:#F0C6C6,hl+:#F0C6C6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/flamingo/catppuccin-fzf.ps1
+++ b/themes/macchiato/flamingo/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F0C6C6
+--color=fg:#CAD3F5,header:#F0C6C6,info:#F0C6C6,pointer:#F0C6C6
+--color=marker:#F0C6C6,fg+:#CAD3F5,prompt:#F0C6C6,hl+:#F0C6C6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/flamingo/catppuccin-fzf.sh
+++ b/themes/macchiato/flamingo/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F0C6C6 \
+--color=fg:#CAD3F5,header:#F0C6C6,info:#F0C6C6,pointer:#F0C6C6 \
+--color=marker:#F0C6C6,fg+:#CAD3F5,prompt:#F0C6C6,hl+:#F0C6C6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/green/catppuccin-fzf.fish
+++ b/themes/macchiato/green/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#A6DA95 \
+--color=fg:#CAD3F5,header:#A6DA95,info:#A6DA95,pointer:#A6DA95 \
+--color=marker:#A6DA95,fg+:#CAD3F5,prompt:#A6DA95,hl+:#A6DA95 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/green/catppuccin-fzf.nu
+++ b/themes/macchiato/green/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#A6DA95
+--color=fg:#CAD3F5,header:#A6DA95,info:#A6DA95,pointer:#A6DA95
+--color=marker:#A6DA95,fg+:#CAD3F5,prompt:#A6DA95,hl+:#A6DA95
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/green/catppuccin-fzf.ps1
+++ b/themes/macchiato/green/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#A6DA95
+--color=fg:#CAD3F5,header:#A6DA95,info:#A6DA95,pointer:#A6DA95
+--color=marker:#A6DA95,fg+:#CAD3F5,prompt:#A6DA95,hl+:#A6DA95
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/green/catppuccin-fzf.sh
+++ b/themes/macchiato/green/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#A6DA95 \
+--color=fg:#CAD3F5,header:#A6DA95,info:#A6DA95,pointer:#A6DA95 \
+--color=marker:#A6DA95,fg+:#CAD3F5,prompt:#A6DA95,hl+:#A6DA95 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/lavender/catppuccin-fzf.fish
+++ b/themes/macchiato/lavender/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#B7BDF8 \
+--color=fg:#CAD3F5,header:#B7BDF8,info:#B7BDF8,pointer:#B7BDF8 \
+--color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#B7BDF8,hl+:#B7BDF8 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/lavender/catppuccin-fzf.nu
+++ b/themes/macchiato/lavender/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#B7BDF8
+--color=fg:#CAD3F5,header:#B7BDF8,info:#B7BDF8,pointer:#B7BDF8
+--color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#B7BDF8,hl+:#B7BDF8
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/lavender/catppuccin-fzf.ps1
+++ b/themes/macchiato/lavender/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#B7BDF8
+--color=fg:#CAD3F5,header:#B7BDF8,info:#B7BDF8,pointer:#B7BDF8
+--color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#B7BDF8,hl+:#B7BDF8
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/lavender/catppuccin-fzf.sh
+++ b/themes/macchiato/lavender/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#B7BDF8 \
+--color=fg:#CAD3F5,header:#B7BDF8,info:#B7BDF8,pointer:#B7BDF8 \
+--color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#B7BDF8,hl+:#B7BDF8 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/maroon/catppuccin-fzf.fish
+++ b/themes/macchiato/maroon/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EE99A0 \
+--color=fg:#CAD3F5,header:#EE99A0,info:#EE99A0,pointer:#EE99A0 \
+--color=marker:#EE99A0,fg+:#CAD3F5,prompt:#EE99A0,hl+:#EE99A0 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/maroon/catppuccin-fzf.nu
+++ b/themes/macchiato/maroon/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EE99A0
+--color=fg:#CAD3F5,header:#EE99A0,info:#EE99A0,pointer:#EE99A0
+--color=marker:#EE99A0,fg+:#CAD3F5,prompt:#EE99A0,hl+:#EE99A0
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/maroon/catppuccin-fzf.ps1
+++ b/themes/macchiato/maroon/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EE99A0
+--color=fg:#CAD3F5,header:#EE99A0,info:#EE99A0,pointer:#EE99A0
+--color=marker:#EE99A0,fg+:#CAD3F5,prompt:#EE99A0,hl+:#EE99A0
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/maroon/catppuccin-fzf.sh
+++ b/themes/macchiato/maroon/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EE99A0 \
+--color=fg:#CAD3F5,header:#EE99A0,info:#EE99A0,pointer:#EE99A0 \
+--color=marker:#EE99A0,fg+:#CAD3F5,prompt:#EE99A0,hl+:#EE99A0 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/mauve/catppuccin-fzf.fish
+++ b/themes/macchiato/mauve/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#C6A0F6 \
+--color=fg:#CAD3F5,header:#C6A0F6,info:#C6A0F6,pointer:#C6A0F6 \
+--color=marker:#C6A0F6,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#C6A0F6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/mauve/catppuccin-fzf.nu
+++ b/themes/macchiato/mauve/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#C6A0F6
+--color=fg:#CAD3F5,header:#C6A0F6,info:#C6A0F6,pointer:#C6A0F6
+--color=marker:#C6A0F6,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#C6A0F6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/mauve/catppuccin-fzf.ps1
+++ b/themes/macchiato/mauve/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#C6A0F6
+--color=fg:#CAD3F5,header:#C6A0F6,info:#C6A0F6,pointer:#C6A0F6
+--color=marker:#C6A0F6,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#C6A0F6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/mauve/catppuccin-fzf.sh
+++ b/themes/macchiato/mauve/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#C6A0F6 \
+--color=fg:#CAD3F5,header:#C6A0F6,info:#C6A0F6,pointer:#C6A0F6 \
+--color=marker:#C6A0F6,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#C6A0F6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/peach/catppuccin-fzf.fish
+++ b/themes/macchiato/peach/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5A97F \
+--color=fg:#CAD3F5,header:#F5A97F,info:#F5A97F,pointer:#F5A97F \
+--color=marker:#F5A97F,fg+:#CAD3F5,prompt:#F5A97F,hl+:#F5A97F \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/peach/catppuccin-fzf.nu
+++ b/themes/macchiato/peach/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5A97F
+--color=fg:#CAD3F5,header:#F5A97F,info:#F5A97F,pointer:#F5A97F
+--color=marker:#F5A97F,fg+:#CAD3F5,prompt:#F5A97F,hl+:#F5A97F
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/peach/catppuccin-fzf.ps1
+++ b/themes/macchiato/peach/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5A97F
+--color=fg:#CAD3F5,header:#F5A97F,info:#F5A97F,pointer:#F5A97F
+--color=marker:#F5A97F,fg+:#CAD3F5,prompt:#F5A97F,hl+:#F5A97F
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/peach/catppuccin-fzf.sh
+++ b/themes/macchiato/peach/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5A97F \
+--color=fg:#CAD3F5,header:#F5A97F,info:#F5A97F,pointer:#F5A97F \
+--color=marker:#F5A97F,fg+:#CAD3F5,prompt:#F5A97F,hl+:#F5A97F \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/pink/catppuccin-fzf.fish
+++ b/themes/macchiato/pink/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5BDE6 \
+--color=fg:#CAD3F5,header:#F5BDE6,info:#F5BDE6,pointer:#F5BDE6 \
+--color=marker:#F5BDE6,fg+:#CAD3F5,prompt:#F5BDE6,hl+:#F5BDE6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/pink/catppuccin-fzf.nu
+++ b/themes/macchiato/pink/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5BDE6
+--color=fg:#CAD3F5,header:#F5BDE6,info:#F5BDE6,pointer:#F5BDE6
+--color=marker:#F5BDE6,fg+:#CAD3F5,prompt:#F5BDE6,hl+:#F5BDE6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/pink/catppuccin-fzf.ps1
+++ b/themes/macchiato/pink/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5BDE6
+--color=fg:#CAD3F5,header:#F5BDE6,info:#F5BDE6,pointer:#F5BDE6
+--color=marker:#F5BDE6,fg+:#CAD3F5,prompt:#F5BDE6,hl+:#F5BDE6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/pink/catppuccin-fzf.sh
+++ b/themes/macchiato/pink/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F5BDE6 \
+--color=fg:#CAD3F5,header:#F5BDE6,info:#F5BDE6,pointer:#F5BDE6 \
+--color=marker:#F5BDE6,fg+:#CAD3F5,prompt:#F5BDE6,hl+:#F5BDE6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/red/catppuccin-fzf.fish
+++ b/themes/macchiato/red/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796 \
+--color=fg:#CAD3F5,header:#ED8796,info:#ED8796,pointer:#ED8796 \
+--color=marker:#ED8796,fg+:#CAD3F5,prompt:#ED8796,hl+:#ED8796 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/red/catppuccin-fzf.nu
+++ b/themes/macchiato/red/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796
+--color=fg:#CAD3F5,header:#ED8796,info:#ED8796,pointer:#ED8796
+--color=marker:#ED8796,fg+:#CAD3F5,prompt:#ED8796,hl+:#ED8796
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/red/catppuccin-fzf.ps1
+++ b/themes/macchiato/red/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796
+--color=fg:#CAD3F5,header:#ED8796,info:#ED8796,pointer:#ED8796
+--color=marker:#ED8796,fg+:#CAD3F5,prompt:#ED8796,hl+:#ED8796
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/red/catppuccin-fzf.sh
+++ b/themes/macchiato/red/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796 \
+--color=fg:#CAD3F5,header:#ED8796,info:#ED8796,pointer:#ED8796 \
+--color=marker:#ED8796,fg+:#CAD3F5,prompt:#ED8796,hl+:#ED8796 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/rosewater/catppuccin-fzf.fish
+++ b/themes/macchiato/rosewater/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F4DBD6 \
+--color=fg:#CAD3F5,header:#F4DBD6,info:#F4DBD6,pointer:#F4DBD6 \
+--color=marker:#F4DBD6,fg+:#CAD3F5,prompt:#F4DBD6,hl+:#F4DBD6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/rosewater/catppuccin-fzf.nu
+++ b/themes/macchiato/rosewater/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F4DBD6
+--color=fg:#CAD3F5,header:#F4DBD6,info:#F4DBD6,pointer:#F4DBD6
+--color=marker:#F4DBD6,fg+:#CAD3F5,prompt:#F4DBD6,hl+:#F4DBD6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/rosewater/catppuccin-fzf.ps1
+++ b/themes/macchiato/rosewater/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F4DBD6
+--color=fg:#CAD3F5,header:#F4DBD6,info:#F4DBD6,pointer:#F4DBD6
+--color=marker:#F4DBD6,fg+:#CAD3F5,prompt:#F4DBD6,hl+:#F4DBD6
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/rosewater/catppuccin-fzf.sh
+++ b/themes/macchiato/rosewater/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#F4DBD6 \
+--color=fg:#CAD3F5,header:#F4DBD6,info:#F4DBD6,pointer:#F4DBD6 \
+--color=marker:#F4DBD6,fg+:#CAD3F5,prompt:#F4DBD6,hl+:#F4DBD6 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/sapphire/catppuccin-fzf.fish
+++ b/themes/macchiato/sapphire/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#7DC4E4 \
+--color=fg:#CAD3F5,header:#7DC4E4,info:#7DC4E4,pointer:#7DC4E4 \
+--color=marker:#7DC4E4,fg+:#CAD3F5,prompt:#7DC4E4,hl+:#7DC4E4 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/sapphire/catppuccin-fzf.nu
+++ b/themes/macchiato/sapphire/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#7DC4E4
+--color=fg:#CAD3F5,header:#7DC4E4,info:#7DC4E4,pointer:#7DC4E4
+--color=marker:#7DC4E4,fg+:#CAD3F5,prompt:#7DC4E4,hl+:#7DC4E4
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/sapphire/catppuccin-fzf.ps1
+++ b/themes/macchiato/sapphire/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#7DC4E4
+--color=fg:#CAD3F5,header:#7DC4E4,info:#7DC4E4,pointer:#7DC4E4
+--color=marker:#7DC4E4,fg+:#CAD3F5,prompt:#7DC4E4,hl+:#7DC4E4
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/sapphire/catppuccin-fzf.sh
+++ b/themes/macchiato/sapphire/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#7DC4E4 \
+--color=fg:#CAD3F5,header:#7DC4E4,info:#7DC4E4,pointer:#7DC4E4 \
+--color=marker:#7DC4E4,fg+:#CAD3F5,prompt:#7DC4E4,hl+:#7DC4E4 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/sky/catppuccin-fzf.fish
+++ b/themes/macchiato/sky/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#91D7E3 \
+--color=fg:#CAD3F5,header:#91D7E3,info:#91D7E3,pointer:#91D7E3 \
+--color=marker:#91D7E3,fg+:#CAD3F5,prompt:#91D7E3,hl+:#91D7E3 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/sky/catppuccin-fzf.nu
+++ b/themes/macchiato/sky/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#91D7E3
+--color=fg:#CAD3F5,header:#91D7E3,info:#91D7E3,pointer:#91D7E3
+--color=marker:#91D7E3,fg+:#CAD3F5,prompt:#91D7E3,hl+:#91D7E3
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/sky/catppuccin-fzf.ps1
+++ b/themes/macchiato/sky/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#91D7E3
+--color=fg:#CAD3F5,header:#91D7E3,info:#91D7E3,pointer:#91D7E3
+--color=marker:#91D7E3,fg+:#CAD3F5,prompt:#91D7E3,hl+:#91D7E3
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/sky/catppuccin-fzf.sh
+++ b/themes/macchiato/sky/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#91D7E3 \
+--color=fg:#CAD3F5,header:#91D7E3,info:#91D7E3,pointer:#91D7E3 \
+--color=marker:#91D7E3,fg+:#CAD3F5,prompt:#91D7E3,hl+:#91D7E3 \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/teal/catppuccin-fzf.fish
+++ b/themes/macchiato/teal/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8BD5CA \
+--color=fg:#CAD3F5,header:#8BD5CA,info:#8BD5CA,pointer:#8BD5CA \
+--color=marker:#8BD5CA,fg+:#CAD3F5,prompt:#8BD5CA,hl+:#8BD5CA \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/teal/catppuccin-fzf.nu
+++ b/themes/macchiato/teal/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8BD5CA
+--color=fg:#CAD3F5,header:#8BD5CA,info:#8BD5CA,pointer:#8BD5CA
+--color=marker:#8BD5CA,fg+:#CAD3F5,prompt:#8BD5CA,hl+:#8BD5CA
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/teal/catppuccin-fzf.ps1
+++ b/themes/macchiato/teal/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8BD5CA
+--color=fg:#CAD3F5,header:#8BD5CA,info:#8BD5CA,pointer:#8BD5CA
+--color=marker:#8BD5CA,fg+:#CAD3F5,prompt:#8BD5CA,hl+:#8BD5CA
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/teal/catppuccin-fzf.sh
+++ b/themes/macchiato/teal/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#8BD5CA \
+--color=fg:#CAD3F5,header:#8BD5CA,info:#8BD5CA,pointer:#8BD5CA \
+--color=marker:#8BD5CA,fg+:#CAD3F5,prompt:#8BD5CA,hl+:#8BD5CA \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/yellow/catppuccin-fzf.fish
+++ b/themes/macchiato/yellow/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EED49F \
+--color=fg:#CAD3F5,header:#EED49F,info:#EED49F,pointer:#EED49F \
+--color=marker:#EED49F,fg+:#CAD3F5,prompt:#EED49F,hl+:#EED49F \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/yellow/catppuccin-fzf.nu
+++ b/themes/macchiato/yellow/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EED49F
+--color=fg:#CAD3F5,header:#EED49F,info:#EED49F,pointer:#EED49F
+--color=marker:#EED49F,fg+:#CAD3F5,prompt:#EED49F,hl+:#EED49F
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/macchiato/yellow/catppuccin-fzf.ps1
+++ b/themes/macchiato/yellow/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EED49F
+--color=fg:#CAD3F5,header:#EED49F,info:#EED49F,pointer:#EED49F
+--color=marker:#EED49F,fg+:#CAD3F5,prompt:#EED49F,hl+:#EED49F
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5
+"@

--- a/themes/macchiato/yellow/catppuccin-fzf.sh
+++ b/themes/macchiato/yellow/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#EED49F \
+--color=fg:#CAD3F5,header:#EED49F,info:#EED49F,pointer:#EED49F \
+--color=marker:#EED49F,fg+:#CAD3F5,prompt:#EED49F,hl+:#EED49F \
+--color=selected-bg:#494D64 \
+--color=border:#6E738D,label:#CAD3F5"

--- a/themes/mocha/blue/catppuccin-fzf.fish
+++ b/themes/mocha/blue/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89B4FA \
+--color=fg:#CDD6F4,header:#89B4FA,info:#89B4FA,pointer:#89B4FA \
+--color=marker:#89B4FA,fg+:#CDD6F4,prompt:#89B4FA,hl+:#89B4FA \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/blue/catppuccin-fzf.nu
+++ b/themes/mocha/blue/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89B4FA
+--color=fg:#CDD6F4,header:#89B4FA,info:#89B4FA,pointer:#89B4FA
+--color=marker:#89B4FA,fg+:#CDD6F4,prompt:#89B4FA,hl+:#89B4FA
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/blue/catppuccin-fzf.ps1
+++ b/themes/mocha/blue/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89B4FA
+--color=fg:#CDD6F4,header:#89B4FA,info:#89B4FA,pointer:#89B4FA
+--color=marker:#89B4FA,fg+:#CDD6F4,prompt:#89B4FA,hl+:#89B4FA
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/blue/catppuccin-fzf.sh
+++ b/themes/mocha/blue/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89B4FA \
+--color=fg:#CDD6F4,header:#89B4FA,info:#89B4FA,pointer:#89B4FA \
+--color=marker:#89B4FA,fg+:#CDD6F4,prompt:#89B4FA,hl+:#89B4FA \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/flamingo/catppuccin-fzf.fish
+++ b/themes/mocha/flamingo/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F2CDCD \
+--color=fg:#CDD6F4,header:#F2CDCD,info:#F2CDCD,pointer:#F2CDCD \
+--color=marker:#F2CDCD,fg+:#CDD6F4,prompt:#F2CDCD,hl+:#F2CDCD \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/flamingo/catppuccin-fzf.nu
+++ b/themes/mocha/flamingo/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F2CDCD
+--color=fg:#CDD6F4,header:#F2CDCD,info:#F2CDCD,pointer:#F2CDCD
+--color=marker:#F2CDCD,fg+:#CDD6F4,prompt:#F2CDCD,hl+:#F2CDCD
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/flamingo/catppuccin-fzf.ps1
+++ b/themes/mocha/flamingo/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F2CDCD
+--color=fg:#CDD6F4,header:#F2CDCD,info:#F2CDCD,pointer:#F2CDCD
+--color=marker:#F2CDCD,fg+:#CDD6F4,prompt:#F2CDCD,hl+:#F2CDCD
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/flamingo/catppuccin-fzf.sh
+++ b/themes/mocha/flamingo/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F2CDCD \
+--color=fg:#CDD6F4,header:#F2CDCD,info:#F2CDCD,pointer:#F2CDCD \
+--color=marker:#F2CDCD,fg+:#CDD6F4,prompt:#F2CDCD,hl+:#F2CDCD \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/green/catppuccin-fzf.fish
+++ b/themes/mocha/green/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#A6E3A1 \
+--color=fg:#CDD6F4,header:#A6E3A1,info:#A6E3A1,pointer:#A6E3A1 \
+--color=marker:#A6E3A1,fg+:#CDD6F4,prompt:#A6E3A1,hl+:#A6E3A1 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/green/catppuccin-fzf.nu
+++ b/themes/mocha/green/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#A6E3A1
+--color=fg:#CDD6F4,header:#A6E3A1,info:#A6E3A1,pointer:#A6E3A1
+--color=marker:#A6E3A1,fg+:#CDD6F4,prompt:#A6E3A1,hl+:#A6E3A1
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/green/catppuccin-fzf.ps1
+++ b/themes/mocha/green/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#A6E3A1
+--color=fg:#CDD6F4,header:#A6E3A1,info:#A6E3A1,pointer:#A6E3A1
+--color=marker:#A6E3A1,fg+:#CDD6F4,prompt:#A6E3A1,hl+:#A6E3A1
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/green/catppuccin-fzf.sh
+++ b/themes/mocha/green/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#A6E3A1 \
+--color=fg:#CDD6F4,header:#A6E3A1,info:#A6E3A1,pointer:#A6E3A1 \
+--color=marker:#A6E3A1,fg+:#CDD6F4,prompt:#A6E3A1,hl+:#A6E3A1 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/lavender/catppuccin-fzf.fish
+++ b/themes/mocha/lavender/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#B4BEFE \
+--color=fg:#CDD6F4,header:#B4BEFE,info:#B4BEFE,pointer:#B4BEFE \
+--color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#B4BEFE,hl+:#B4BEFE \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/lavender/catppuccin-fzf.nu
+++ b/themes/mocha/lavender/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#B4BEFE
+--color=fg:#CDD6F4,header:#B4BEFE,info:#B4BEFE,pointer:#B4BEFE
+--color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#B4BEFE,hl+:#B4BEFE
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/lavender/catppuccin-fzf.ps1
+++ b/themes/mocha/lavender/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#B4BEFE
+--color=fg:#CDD6F4,header:#B4BEFE,info:#B4BEFE,pointer:#B4BEFE
+--color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#B4BEFE,hl+:#B4BEFE
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/lavender/catppuccin-fzf.sh
+++ b/themes/mocha/lavender/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#B4BEFE \
+--color=fg:#CDD6F4,header:#B4BEFE,info:#B4BEFE,pointer:#B4BEFE \
+--color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#B4BEFE,hl+:#B4BEFE \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/maroon/catppuccin-fzf.fish
+++ b/themes/mocha/maroon/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#EBA0AC \
+--color=fg:#CDD6F4,header:#EBA0AC,info:#EBA0AC,pointer:#EBA0AC \
+--color=marker:#EBA0AC,fg+:#CDD6F4,prompt:#EBA0AC,hl+:#EBA0AC \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/maroon/catppuccin-fzf.nu
+++ b/themes/mocha/maroon/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#EBA0AC
+--color=fg:#CDD6F4,header:#EBA0AC,info:#EBA0AC,pointer:#EBA0AC
+--color=marker:#EBA0AC,fg+:#CDD6F4,prompt:#EBA0AC,hl+:#EBA0AC
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/maroon/catppuccin-fzf.ps1
+++ b/themes/mocha/maroon/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#EBA0AC
+--color=fg:#CDD6F4,header:#EBA0AC,info:#EBA0AC,pointer:#EBA0AC
+--color=marker:#EBA0AC,fg+:#CDD6F4,prompt:#EBA0AC,hl+:#EBA0AC
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/maroon/catppuccin-fzf.sh
+++ b/themes/mocha/maroon/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#EBA0AC \
+--color=fg:#CDD6F4,header:#EBA0AC,info:#EBA0AC,pointer:#EBA0AC \
+--color=marker:#EBA0AC,fg+:#CDD6F4,prompt:#EBA0AC,hl+:#EBA0AC \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/mauve/catppuccin-fzf.fish
+++ b/themes/mocha/mauve/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#CBA6F7 \
+--color=fg:#CDD6F4,header:#CBA6F7,info:#CBA6F7,pointer:#CBA6F7 \
+--color=marker:#CBA6F7,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#CBA6F7 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/mauve/catppuccin-fzf.nu
+++ b/themes/mocha/mauve/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#CBA6F7
+--color=fg:#CDD6F4,header:#CBA6F7,info:#CBA6F7,pointer:#CBA6F7
+--color=marker:#CBA6F7,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#CBA6F7
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/mauve/catppuccin-fzf.ps1
+++ b/themes/mocha/mauve/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#CBA6F7
+--color=fg:#CDD6F4,header:#CBA6F7,info:#CBA6F7,pointer:#CBA6F7
+--color=marker:#CBA6F7,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#CBA6F7
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/mauve/catppuccin-fzf.sh
+++ b/themes/mocha/mauve/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#CBA6F7 \
+--color=fg:#CDD6F4,header:#CBA6F7,info:#CBA6F7,pointer:#CBA6F7 \
+--color=marker:#CBA6F7,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#CBA6F7 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/peach/catppuccin-fzf.fish
+++ b/themes/mocha/peach/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#FAB387 \
+--color=fg:#CDD6F4,header:#FAB387,info:#FAB387,pointer:#FAB387 \
+--color=marker:#FAB387,fg+:#CDD6F4,prompt:#FAB387,hl+:#FAB387 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/peach/catppuccin-fzf.nu
+++ b/themes/mocha/peach/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#FAB387
+--color=fg:#CDD6F4,header:#FAB387,info:#FAB387,pointer:#FAB387
+--color=marker:#FAB387,fg+:#CDD6F4,prompt:#FAB387,hl+:#FAB387
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/peach/catppuccin-fzf.ps1
+++ b/themes/mocha/peach/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#FAB387
+--color=fg:#CDD6F4,header:#FAB387,info:#FAB387,pointer:#FAB387
+--color=marker:#FAB387,fg+:#CDD6F4,prompt:#FAB387,hl+:#FAB387
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/peach/catppuccin-fzf.sh
+++ b/themes/mocha/peach/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#FAB387 \
+--color=fg:#CDD6F4,header:#FAB387,info:#FAB387,pointer:#FAB387 \
+--color=marker:#FAB387,fg+:#CDD6F4,prompt:#FAB387,hl+:#FAB387 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/pink/catppuccin-fzf.fish
+++ b/themes/mocha/pink/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5C2E7 \
+--color=fg:#CDD6F4,header:#F5C2E7,info:#F5C2E7,pointer:#F5C2E7 \
+--color=marker:#F5C2E7,fg+:#CDD6F4,prompt:#F5C2E7,hl+:#F5C2E7 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/pink/catppuccin-fzf.nu
+++ b/themes/mocha/pink/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5C2E7
+--color=fg:#CDD6F4,header:#F5C2E7,info:#F5C2E7,pointer:#F5C2E7
+--color=marker:#F5C2E7,fg+:#CDD6F4,prompt:#F5C2E7,hl+:#F5C2E7
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/pink/catppuccin-fzf.ps1
+++ b/themes/mocha/pink/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5C2E7
+--color=fg:#CDD6F4,header:#F5C2E7,info:#F5C2E7,pointer:#F5C2E7
+--color=marker:#F5C2E7,fg+:#CDD6F4,prompt:#F5C2E7,hl+:#F5C2E7
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/pink/catppuccin-fzf.sh
+++ b/themes/mocha/pink/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5C2E7 \
+--color=fg:#CDD6F4,header:#F5C2E7,info:#F5C2E7,pointer:#F5C2E7 \
+--color=marker:#F5C2E7,fg+:#CDD6F4,prompt:#F5C2E7,hl+:#F5C2E7 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/red/catppuccin-fzf.fish
+++ b/themes/mocha/red/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8 \
+--color=fg:#CDD6F4,header:#F38BA8,info:#F38BA8,pointer:#F38BA8 \
+--color=marker:#F38BA8,fg+:#CDD6F4,prompt:#F38BA8,hl+:#F38BA8 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/red/catppuccin-fzf.nu
+++ b/themes/mocha/red/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
+--color=fg:#CDD6F4,header:#F38BA8,info:#F38BA8,pointer:#F38BA8
+--color=marker:#F38BA8,fg+:#CDD6F4,prompt:#F38BA8,hl+:#F38BA8
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/red/catppuccin-fzf.ps1
+++ b/themes/mocha/red/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
+--color=fg:#CDD6F4,header:#F38BA8,info:#F38BA8,pointer:#F38BA8
+--color=marker:#F38BA8,fg+:#CDD6F4,prompt:#F38BA8,hl+:#F38BA8
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/red/catppuccin-fzf.sh
+++ b/themes/mocha/red/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8 \
+--color=fg:#CDD6F4,header:#F38BA8,info:#F38BA8,pointer:#F38BA8 \
+--color=marker:#F38BA8,fg+:#CDD6F4,prompt:#F38BA8,hl+:#F38BA8 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/rosewater/catppuccin-fzf.fish
+++ b/themes/mocha/rosewater/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5E0DC \
+--color=fg:#CDD6F4,header:#F5E0DC,info:#F5E0DC,pointer:#F5E0DC \
+--color=marker:#F5E0DC,fg+:#CDD6F4,prompt:#F5E0DC,hl+:#F5E0DC \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/rosewater/catppuccin-fzf.nu
+++ b/themes/mocha/rosewater/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5E0DC
+--color=fg:#CDD6F4,header:#F5E0DC,info:#F5E0DC,pointer:#F5E0DC
+--color=marker:#F5E0DC,fg+:#CDD6F4,prompt:#F5E0DC,hl+:#F5E0DC
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/rosewater/catppuccin-fzf.ps1
+++ b/themes/mocha/rosewater/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5E0DC
+--color=fg:#CDD6F4,header:#F5E0DC,info:#F5E0DC,pointer:#F5E0DC
+--color=marker:#F5E0DC,fg+:#CDD6F4,prompt:#F5E0DC,hl+:#F5E0DC
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/rosewater/catppuccin-fzf.sh
+++ b/themes/mocha/rosewater/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F5E0DC \
+--color=fg:#CDD6F4,header:#F5E0DC,info:#F5E0DC,pointer:#F5E0DC \
+--color=marker:#F5E0DC,fg+:#CDD6F4,prompt:#F5E0DC,hl+:#F5E0DC \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/sapphire/catppuccin-fzf.fish
+++ b/themes/mocha/sapphire/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#74C7EC \
+--color=fg:#CDD6F4,header:#74C7EC,info:#74C7EC,pointer:#74C7EC \
+--color=marker:#74C7EC,fg+:#CDD6F4,prompt:#74C7EC,hl+:#74C7EC \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/sapphire/catppuccin-fzf.nu
+++ b/themes/mocha/sapphire/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#74C7EC
+--color=fg:#CDD6F4,header:#74C7EC,info:#74C7EC,pointer:#74C7EC
+--color=marker:#74C7EC,fg+:#CDD6F4,prompt:#74C7EC,hl+:#74C7EC
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/sapphire/catppuccin-fzf.ps1
+++ b/themes/mocha/sapphire/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#74C7EC
+--color=fg:#CDD6F4,header:#74C7EC,info:#74C7EC,pointer:#74C7EC
+--color=marker:#74C7EC,fg+:#CDD6F4,prompt:#74C7EC,hl+:#74C7EC
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/sapphire/catppuccin-fzf.sh
+++ b/themes/mocha/sapphire/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#74C7EC \
+--color=fg:#CDD6F4,header:#74C7EC,info:#74C7EC,pointer:#74C7EC \
+--color=marker:#74C7EC,fg+:#CDD6F4,prompt:#74C7EC,hl+:#74C7EC \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/sky/catppuccin-fzf.fish
+++ b/themes/mocha/sky/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89DCEB \
+--color=fg:#CDD6F4,header:#89DCEB,info:#89DCEB,pointer:#89DCEB \
+--color=marker:#89DCEB,fg+:#CDD6F4,prompt:#89DCEB,hl+:#89DCEB \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/sky/catppuccin-fzf.nu
+++ b/themes/mocha/sky/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89DCEB
+--color=fg:#CDD6F4,header:#89DCEB,info:#89DCEB,pointer:#89DCEB
+--color=marker:#89DCEB,fg+:#CDD6F4,prompt:#89DCEB,hl+:#89DCEB
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/sky/catppuccin-fzf.ps1
+++ b/themes/mocha/sky/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89DCEB
+--color=fg:#CDD6F4,header:#89DCEB,info:#89DCEB,pointer:#89DCEB
+--color=marker:#89DCEB,fg+:#CDD6F4,prompt:#89DCEB,hl+:#89DCEB
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/sky/catppuccin-fzf.sh
+++ b/themes/mocha/sky/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#89DCEB \
+--color=fg:#CDD6F4,header:#89DCEB,info:#89DCEB,pointer:#89DCEB \
+--color=marker:#89DCEB,fg+:#CDD6F4,prompt:#89DCEB,hl+:#89DCEB \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/teal/catppuccin-fzf.fish
+++ b/themes/mocha/teal/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#94E2D5 \
+--color=fg:#CDD6F4,header:#94E2D5,info:#94E2D5,pointer:#94E2D5 \
+--color=marker:#94E2D5,fg+:#CDD6F4,prompt:#94E2D5,hl+:#94E2D5 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/teal/catppuccin-fzf.nu
+++ b/themes/mocha/teal/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#94E2D5
+--color=fg:#CDD6F4,header:#94E2D5,info:#94E2D5,pointer:#94E2D5
+--color=marker:#94E2D5,fg+:#CDD6F4,prompt:#94E2D5,hl+:#94E2D5
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/teal/catppuccin-fzf.ps1
+++ b/themes/mocha/teal/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#94E2D5
+--color=fg:#CDD6F4,header:#94E2D5,info:#94E2D5,pointer:#94E2D5
+--color=marker:#94E2D5,fg+:#CDD6F4,prompt:#94E2D5,hl+:#94E2D5
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/teal/catppuccin-fzf.sh
+++ b/themes/mocha/teal/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#94E2D5 \
+--color=fg:#CDD6F4,header:#94E2D5,info:#94E2D5,pointer:#94E2D5 \
+--color=marker:#94E2D5,fg+:#CDD6F4,prompt:#94E2D5,hl+:#94E2D5 \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/yellow/catppuccin-fzf.fish
+++ b/themes/mocha/yellow/catppuccin-fzf.fish
@@ -1,0 +1,6 @@
+set -Ux FZF_DEFAULT_OPTS "\
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F9E2AF \
+--color=fg:#CDD6F4,header:#F9E2AF,info:#F9E2AF,pointer:#F9E2AF \
+--color=marker:#F9E2AF,fg+:#CDD6F4,prompt:#F9E2AF,hl+:#F9E2AF \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/yellow/catppuccin-fzf.nu
+++ b/themes/mocha/yellow/catppuccin-fzf.nu
@@ -1,0 +1,6 @@
+$env.FZF_DEFAULT_OPTS = "
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F9E2AF
+--color=fg:#CDD6F4,header:#F9E2AF,info:#F9E2AF,pointer:#F9E2AF
+--color=marker:#F9E2AF,fg+:#CDD6F4,prompt:#F9E2AF,hl+:#F9E2AF
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4"

--- a/themes/mocha/yellow/catppuccin-fzf.ps1
+++ b/themes/mocha/yellow/catppuccin-fzf.ps1
@@ -1,0 +1,7 @@
+$ENV:FZF_DEFAULT_OPTS=@"
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F9E2AF
+--color=fg:#CDD6F4,header:#F9E2AF,info:#F9E2AF,pointer:#F9E2AF
+--color=marker:#F9E2AF,fg+:#CDD6F4,prompt:#F9E2AF,hl+:#F9E2AF
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4
+"@

--- a/themes/mocha/yellow/catppuccin-fzf.sh
+++ b/themes/mocha/yellow/catppuccin-fzf.sh
@@ -1,0 +1,6 @@
+export FZF_DEFAULT_OPTS=" \
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F9E2AF \
+--color=fg:#CDD6F4,header:#F9E2AF,info:#F9E2AF,pointer:#F9E2AF \
+--color=marker:#F9E2AF,fg+:#CDD6F4,prompt:#F9E2AF,hl+:#F9E2AF \
+--color=selected-bg:#45475A \
+--color=border:#6C7086,label:#CDD6F4"


### PR DESCRIPTION
Adds accent support. I had to put the themes into different folders based on accent and color, so this potentially supersedes #23

This depends on #26, but if that does not get merged for whatever reason, I will change this PR to reflect that.