### PR TITLE
feat: add support for fzfrc

### DIFF
--- a/fzf.tera
+++ b/fzf.tera
@@ -3,7 +3,7 @@ whiskers:
   version: ^2.5.1
   matrix:
     - flavor
-    - variant: ["sh", "fish", "nu", "ps1"]
+    - variant: ["sh", "fish", "nu", "ps1", "rc"]
   filename: "themes/catppuccin-fzf-{{ flavor.identifier }}.{{ variant }}"
   hex_format: "#{{R}}{{G}}{{B}}{{Z}}"
 ---
@@ -15,24 +15,26 @@ whiskers:
 {% macro theme_start() %}
   {%- if variant == "sh" -%}
 export FZF_DEFAULT_OPTS=" \
-  {%- elif variant == "fish" -%}
+{% elif variant == "fish" -%}
 set -Ux FZF_DEFAULT_OPTS "\
-  {%- elif variant == "nu" -%}
+{% elif variant == "nu" -%}
 $env.FZF_DEFAULT_OPTS = "
-  {%- elif variant == "ps1" -%}
+{% elif variant == "ps1" -%}
 $ENV:FZF_DEFAULT_OPTS=@"
-  {%- endif -%}
+{% endif -%}
 {%- endmacro theme_start -%}
 
 {% macro theme_end() %}
   {%- if variant == "ps1" %}
 "@
+  {%- elif variant == "rc" -%}
+
   {%- else -%}
 "
   {%- endif -%}
 {%- endmacro theme_end -%}
 
-{{self::theme_start()}}
+{{self::theme_start() -}}
 --color=bg+:{{surface0.hex}},bg:{{base.hex}},spinner:{{rosewater.hex}},hl:{{red.hex}}{{self::line_end()}}
 --color=fg:{{text.hex}},header:{{red.hex}},info:{{mauve.hex}},pointer:{{rosewater.hex}}{{self::line_end()}}
 --color=marker:{{lavender.hex}},fg+:{{text.hex}},prompt:{{mauve.hex}},hl+:{{red.hex}}{{self::line_end()}}

--- a/themes/catppuccin-fzf-frappe.rc
+++ b/themes/catppuccin-fzf-frappe.rc
@@ -1,0 +1,5 @@
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284
+--color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF
+--color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284
+--color=selected-bg:#51576D
+--color=border:#737994,label:#C6D0F5

--- a/themes/catppuccin-fzf-latte.rc
+++ b/themes/catppuccin-fzf-latte.rc
@@ -1,0 +1,5 @@
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39
+--color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78
+--color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39
+--color=selected-bg:#BCC0CC
+--color=border:#9CA0B0,label:#4C4F69

--- a/themes/catppuccin-fzf-macchiato.rc
+++ b/themes/catppuccin-fzf-macchiato.rc
@@ -1,0 +1,5 @@
+--color=bg+:#363A4F,bg:#24273A,spinner:#F4DBD6,hl:#ED8796
+--color=fg:#CAD3F5,header:#ED8796,info:#C6A0F6,pointer:#F4DBD6
+--color=marker:#B7BDF8,fg+:#CAD3F5,prompt:#C6A0F6,hl+:#ED8796
+--color=selected-bg:#494D64
+--color=border:#6E738D,label:#CAD3F5

--- a/themes/catppuccin-fzf-mocha.rc
+++ b/themes/catppuccin-fzf-mocha.rc
@@ -1,0 +1,5 @@
+--color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
+--color=fg:#CDD6F4,header:#F38BA8,info:#CBA6F7,pointer:#F5E0DC
+--color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8
+--color=selected-bg:#45475A
+--color=border:#6C7086,label:#CDD6F4


### PR DESCRIPTION
FZF_DEFAULT_OPTS_FILE was added in https://github.com/junegunn/fzf/releases/tag/0.47.0
making it possible to source a file for your config options. this seems
to be a preferible way to configure fzf with nix
